### PR TITLE
replace deprecated thrnio/ip 

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+2019-02-09 Release 1.2.2
+- replace deprecated thrnio/ip lib with stdlib for validating IPs
+2019-01-14 Release 1.2.1
+- notify service on change config
+- add firewall chain for udp
 2018-07-19 Release 1.2.0
 - Made dependency o stahnma/epel contingent on being RedHat
 - Allowed Puppet 5

--- a/doc/puppet_classes/fail2ban.html
+++ b/doc/puppet_classes/fail2ban.html
@@ -451,7 +451,7 @@ belonging to each fail2ban jail.</p>
         <span class='name'>ignoreip</span>
       
       
-        <span class='type'>(<tt>Optional[Array[Variant[IP::Address::NoSubnet, IP::Address::V4::CIDR, String]]]</tt>)</span>
+        <span class='type'>(<tt>Optional[Array[Variant[Stdlib::IP::Address::V4, String]]]</tt>)</span>
       
       
         <em class="default">(defaults to: <tt>undef</tt>)</em>
@@ -597,7 +597,7 @@ jail.local.</p>
 class fail2ban (
   String $package_name                   = &#39;fail2ban&#39;,
   String $package_ensure                 = &#39;latest&#39;,
-  Optional[Array[Variant[IP::Address::NoSubnet, IP::Address::V4::CIDR, String]]] $ignoreip = undef,
+  Optional[Array[Variant[Stdlib::IP::Address::V4, String]]] $ignoreip = undef,
 
   Optional[Enum[&#39;CRITICAL&#39;, &#39;ERROR&#39;,
                 &#39;WARNING&#39;, &#39;NOTICE&#39;,

--- a/doc/puppet_defined_types/fail2ban_3A_3Ajail.html
+++ b/doc/puppet_defined_types/fail2ban_3A_3Ajail.html
@@ -333,7 +333,7 @@ jail.local.</p>
         <span class='name'>ignoreip</span>
       
       
-        <span class='type'>(<tt>Array[Variant[IP::Address::NoSubnet, IP::Address::V4::CIDR, String]]</tt>)</span>
+        <span class='type'>(<tt>Array[Variant[Stdlib::IP::Address::V4, String]]</tt>)</span>
       
       
         <em class="default">(defaults to: <tt>[]</tt>)</em>
@@ -456,7 +456,7 @@ define fail2ban::jail (
   Optional[String]  $action    = undef,
   Optional[String]  $banaction = undef,
   Optional[Integer] $bantime   = undef,
-  Array[Variant[IP::Address::NoSubnet, IP::Address::V4::CIDR, String]] $ignoreip = [],
+  Array[Variant[Stdlib::IP::Address::V4, String]] $ignoreip = [],
   Optional[Integer] $order     = undef,
   Optional[Enum[&#39;pyinotify&#39;, &#39;gamin&#39;, &#39;polling&#39;, &#39;systemd&#39;, &#39;auto&#39;]] $backend  = undef,
   ) {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,7 +34,7 @@
 class fail2ban (
   String $package_name                   = 'fail2ban',
   String $package_ensure                 = 'latest',
-  Optional[Array[Variant[IP::Address::NoSubnet, IP::Address::V4::CIDR, String]]] $ignoreip = undef,
+  Optional[Array[Variant[Stdlib::IP::Address::V4, String]]] $ignoreip = undef,
 
   Optional[Enum['CRITICAL', 'ERROR',
                 'WARNING', 'NOTICE',

--- a/manifests/jail.pp
+++ b/manifests/jail.pp
@@ -56,7 +56,7 @@ define fail2ban::jail (
   Optional[String]  $action    = undef,
   Optional[String]  $banaction = undef,
   Optional[Integer] $bantime   = undef,
-  Array[Variant[IP::Address::NoSubnet, IP::Address::V4::CIDR, String]] $ignoreip = [],
+  Array[Variant[Stdlib::IP::Address::V4, String]] $ignoreip = [],
   Optional[Integer] $order     = undef,
   Optional[Enum['pyinotify', 'gamin', 'polling', 'systemd', 'auto']] $backend  = undef,
   Optional[String] $comment = '',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "calmenergy-fail2ban",
-  "version": "1.2.0",
+  "version": "1.2.2",
   "author": "CALM Energy, Inc.",
   "summary": "Manage fail2ban; works with roles/profiles; plays nicely with firewall module",
   "license": "Apache-2.0",
@@ -24,12 +24,7 @@
     {
       "name":  "puppetlabs/firewall",
       "version_requirement": ">= 1.8.2 < 2.0.0"
-    },
-    {
-      "name":  "thrnio/ip",
-      "version_requirement": ">= 1.0.0 < 2.0.0"
     }
-
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
according to https://github.com/thrnio/puppet-ip a required dependency is deprecated, i replaced the param types with compatible stdlib types.